### PR TITLE
Tidy logger.py and Correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,30 @@ Consider support us on [Patreon](https://www.patreon.com/sekaisoft) :)
 ## Development
 Developed on Python 3.12.1 on Windows 11
 
+(Run the commands below in Command Prompt)
+
 ### Install dependencies
 ```
 python -m venv venv
-.\venv\Scripts\activate
+.\venv\Scripts\activate.bat
 pip install -r requirements.txt
 ```
 
 ### Run unit tests
 ```
-.\venv\Scripts\activate
+.\venv\Scripts\activate.bat
 python -m unittest discover
 ```
 
 ### Run program without packaging
 ```
-.\venv\Scripts\activate
+.\venv\Scripts\activate.bat
 pythonw .\tray.py
 ```
 
 ### Package Windows app
 ```
-.\venv\Scripts\activate
+.\venv\Scripts\activate.bat
 pyinstaller --name "Code Opener" --windowed --uac-admin --icon icon.ico --clean .\tray.py
 cp icon.ico "dist\Code Opener"
 ```

--- a/codeopener/logger.py
+++ b/codeopener/logger.py
@@ -1,26 +1,32 @@
 import logging
 from logging.handlers import RotatingFileHandler
 
-# Create a logger
+"""
+Create a logger and set the logging level,
+then create a formatter for the handlers
+"""
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)  # Set the logging level
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # Create a file handler
 log_file = 'code-opener.log'
 file_handler = RotatingFileHandler(log_file, maxBytes=100000, backupCount=5)
-file_handler.setLevel(logging.DEBUG)  # Set the logging level for the file
 
 # Create a stream handler for stdout
-# stream_handler = logging.StreamHandler()
-# stream_handler.setLevel(logging.DEBUG)  # Set the logging level for stdout
+# stream_handler = logging.StreamHandler(sys.stdout)
+stream_handler = None 
 
-# Create a formatter
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-# Set the formatter for the handlers
+"""
+Set logging level and formatter for the file_handler,
+then add the file_handler to the logger
+"""
+file_handler.setLevel(logging.DEBUG)  
 file_handler.setFormatter(formatter)
-# stream_handler.setFormatter(formatter)
-
-# Add the handlers to the logger
 logger.addHandler(file_handler)
-# logger.addHandler(stream_handler)
+
+if stream_handler is not None:
+    # the same as above
+    stream_handler.setLevel(logging.DEBUG)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)


### PR DESCRIPTION
`# stream_handler = logging.StreamHandler(sys.stdout)`

logging.StreamHandler Initializes the handler.
But, **if the argument "stream" is not specified, sys.stderr is used for it.**
According to the comment above it, it's output should print to sys.stdout, so it is necessary to specify the argument "stream".